### PR TITLE
Improve instrument-specific key signatures example

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@ trombone:             o3 e8 f g a b > c d   e4.
   o4 c8 d e f g a b > c4.
 
 tuba:
-  o4 c8 d e f g a b > c4.
+  o2 e8 f g a b > c d e4.
 </code></pre>
 					<audio controls><source src="demos/keysig1.ogg" type="audio/ogg" /></audio><br/>
 <pre><code class="hljs" contenteditable>trumpet:
@@ -241,7 +241,7 @@ tuba:
 
 tuba:
   (key-signature [:e :flat :major])
-  o4 c8 d e f g a b > c4.
+  o2 e8 f g a b > c d e4.
 </code></pre>
 					<audio controls><source src="demos/keysig2.ogg" type="audio/ogg" /></audio><br/>
 				</section>


### PR DESCRIPTION
I think this small change to the trumpet/tuba with 2 different key signatures example might better illustrate how it could be interesting to write a piece of music where the instruments are playing in different keys. The difference is subtle, but if you play `keysig1.alda` and `keysig2.alda` back to back, you can hear the difference in character.

I also bumped the tuba down a couple of octaves, which makes it a little easier for the listener to tell the two instruments apart.

BTW, out of curiosity, how are you generating your ogg files? 
